### PR TITLE
fixed unregistering of gazebo events in destructor

### DIFF
--- a/include/rtt-gazebo-robot-sim.hpp
+++ b/include/rtt-gazebo-robot-sim.hpp
@@ -42,7 +42,7 @@ public:
     void updateHook();
     void WorldUpdateBegin();
     void WorldUpdateEnd();
-    virtual ~robotSim() {}
+    ~robotSim();
 
 protected:
     bool getModel(const std::string& model_name);

--- a/src/rtt-gazebo-robot-sim.cpp
+++ b/src/rtt-gazebo-robot-sim.cpp
@@ -252,7 +252,11 @@ bool robotSim::setInitialPosition(const std::string& kin_chain, const std::vecto
     return a;
 }
 
-
+robotSim::~robotSim() {
+    // Disconnect slots
+    gazebo::event::Events::DisconnectWorldUpdateBegin(world_begin);
+    gazebo::event::Events::DisconnectWorldUpdateEnd(world_end);
+}
 
 ORO_CREATE_COMPONENT_LIBRARY()
 //ORO_CREATE_COMPONENT(cogimon::robotSim)


### PR DESCRIPTION
This is necessary so that Orocos can properly unload this component.